### PR TITLE
Fix and simplify logic for lifecycle rules

### DIFF
--- a/yes3.py
+++ b/yes3.py
@@ -413,11 +413,10 @@ for bucket in s3_buckets['Buckets']:
         for rule in lifecycle_rules:
             lifecycle = "no_expiration"
 
-            if 'Expiration' in rule.keys():
-                if rule.get('Expiration').get("Days") or rule.get("NoncurrentVersionExpiration"):
-                    lifecycle = "expiration"
-                    add_to_bucket_summary("LifecycleConfig", bucket_name)
-                    break
+            if rule.get("Expiration") or rule.get("NoncurrentVersionExpiration"):
+                lifecycle = "expiration"
+                add_to_bucket_summary("LifecycleConfig", bucket_name)
+                break
 
     except botocore.exceptions.ClientError as error:
         if error.response['Error']['Code'] == 'AccessDenied':


### PR DESCRIPTION
Lifecycle rules cannot exist for expiration without days specified.  Changing logic to only check for the rule (and not days)