### PR TITLE
Fix: Service Quota Region Call

### DIFF
--- a/yes3.py
+++ b/yes3.py
@@ -3,8 +3,10 @@ import botocore
 import argparse
 
 def check_bucket_limit(session, region):
+    
     #Service Quota Code: L-DC2B2D3D
-    sq_client = session.client('service-quotas', region)
+    #Hardcoded region for us-east-1 to see Global Quota for S3 Buckets
+    sq_client = session.client('service-quotas', 'us-east-1')
 
     try:
         response = sq_client.get_service_quota(


### PR DESCRIPTION
Global Bucket Service Quota is only in us-east-1.  Fixing region call to hard code us-east-1 for SQ Client.  Eventually can take out region parameter.