### PR TITLE
Update Region Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ YES3 Scanner checks for the following S3 configuration items:
 python3 yes3.py --profile <your_profile_here>
 ```
 
+Note: While S3 is global, certain clients in AWS's boto3 require regions such as Service Quotas, S3 Control, and STS.  YES3 Scanner uses Service Quotas to check for bucket limits and the global limit only shows up in us-east-1.  Due to this, YES3 scanner will use `us-east-1 ` as the default region for Service Quotas, STS, and S3 Control. YES3 Scanner will account for buckets in all regions due to the global nature of S3.  Thus, YES3's API calls will be in CloudTrail in us-east-1.
+
 Example output:
 
 ```

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ YES3 Scanner checks for the following S3 configuration items:
 ## Running YES3 Scanner
 
 ```
-python3 yes3.py --profile <your_profile_here> --region <region_specifier>
+python3 yes3.py --profile <your_profile_here>
 ```
-
-Note: While S3 is global, YES3 will check Service Quotas for bucket limits and thus will need a region specified for the BOTO3 client.  It will check S3 globally (assuming proper permissions) as well as the account (global) limit for buckets.
 
 Example output:
 

--- a/yes3.py
+++ b/yes3.py
@@ -164,6 +164,7 @@ def add_to_bucket_summary(category, bucket_name):
 
 parser = argparse.ArgumentParser(prog='YES3 Scanner') 
 parser.add_argument("--profile")
+parser.add_argument("--region")
 
 args = parser.parse_args()
 session = boto3.Session(profile_name = args.profile)

--- a/yes3.py
+++ b/yes3.py
@@ -2,7 +2,7 @@ import boto3
 import botocore
 import argparse
 
-def check_bucket_limit(session, region):
+def check_bucket_limit(session):
     
     #Service Quota Code: L-DC2B2D3D
     #Hardcoded region for us-east-1 to see Global Quota for S3 Buckets
@@ -54,7 +54,7 @@ def potential_public(bucket_results, account_results):
 
 def summarize_results(bucket_results, account_results, bucket_results_summary):
     #Process and print out results
-    sts_client = session.client('sts', region)
+    sts_client = session.client('sts', 'us-east-1')
     aws_account = sts_client.get_caller_identity()['Account']
 
     #Account Results
@@ -164,21 +164,19 @@ def add_to_bucket_summary(category, bucket_name):
 
 parser = argparse.ArgumentParser(prog='YES3 Scanner') 
 parser.add_argument("--profile")
-parser.add_argument("--region")
 
 args = parser.parse_args()
 session = boto3.Session(profile_name = args.profile)
-region = args.region
 
 s3_client = session.client('s3')
-s3_control_client = session.client('s3control', region_name=region)
+s3_control_client = session.client('s3control', 'us-east-1')
 # Account Configuration Checks
 # Account Public Access Block 
 
 sts_client = session.client('sts')
 account = sts_client.get_caller_identity()['Account']
 
-check_bucket_limit(session, region)
+check_bucket_limit(session)
 
 try:
     account_block_settings = s3_control_client.get_public_access_block(


### PR DESCRIPTION
This PR covers the following:

- Hard codes a region for Service Quotas for Global S3 Bucket Quota as other regions can cause non-breaking errors.
- Hard codes a region so all YES3 Scanner calls are through us-east-1.
- Keep parser argument in for backwards compatibility.  

S3 is a global service, so buckets will be shown globally in YES3.