### PR TITLE
Add Handling for Bucket Block Public Access Not Existing

### DIFF
--- a/yes3.py
+++ b/yes3.py
@@ -265,6 +265,14 @@ for bucket in s3_buckets['Buckets']:
         if error.response['Error']['Code'] == 'AccessDenied':
             access_issue("BucketBPA", bucket_name)
             bucket_bpa_config = "access_error"
+        elif error.response['Error']['Code'] == 'NoSuchPublicAccessBlockConfiguration':
+            bucket_bpa_config = {'BlockPublicAcls': False,
+                'IgnorePublicAcls': False,
+                'BlockPublicPolicy': False,
+                'RestrictPublicBuckets': False
+            }
+            
+            add_to_bucket_summary("BucketBPA", bucket_name)
         else:
             raise error
 


### PR DESCRIPTION
This is the corresponding PR that should fix Issue #8, (Add Handling for Get Public Access Block).

In some cases, S3 buckets may not return a Public Access Block (For example, when a bucket's public access block settings are deleted via `aws s3api delete-public-access-block`)
 
Error returned by CLI: NoSuchPublicAccessBlockConfiguration.

The code submitted will catch the error and handle it as the bucket's BPA settings are all set to false (as a deleted BPA setting results in no BPA settings, effectively all set to false).