### PR TITLE
Add Ability to take CLI Input of Buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ python3 yes3.py --profile <your_profile_here>
 
 Note: While S3 is global, certain clients in AWS's boto3 require regions such as Service Quotas, S3 Control, and STS.  YES3 Scanner uses Service Quotas to check for bucket limits and the global limit only shows up in us-east-1.  Due to this, YES3 scanner will use `us-east-1 ` as the default region for Service Quotas, STS, and S3 Control. YES3 Scanner will account for buckets in all regions due to the global nature of S3.  Thus, YES3's API calls will be in CloudTrail in us-east-1.
 
+### Optional: Pass in buckets to scan
+
+By default, YES3 Scanner will scan all buckets in the region in the AWS Account.  To specify specific buckets to run YES3 Scanner on, the `--buckets` argument can be used.  The `--buckets` argument takes in a comma-separated list of bucket names (without spaces).
+
+Example command:
+
+```
+python3 yes3.py --profile <your_profile_here>  --buckets fog-bucket-1,fog-bucket-2,fog-bucket-3
+```
+
+
+### Example Output
+
 Example output:
 
 ```
@@ -73,7 +86,7 @@ Account Settings
 Account Block Public Access Overall Status: OK
 ----------------------------
 Bucket Summary
-Total Buckets: 14
+Buckets Scanned: 14
 ----------------------------
 Buckets potentially public: 3
 fog-pub-sample-bucket | Public Method: ['acl']

--- a/yes3.py
+++ b/yes3.py
@@ -254,9 +254,16 @@ for bucket in bucket_listing:
     except botocore.exceptions.ClientError as error:
         if error.response['Error']['Code'] == 'AccessDenied':
             access_issue("BucketEncryption", bucket_name)
+        elif error.response['Error']['Code'] == 'NoSuchBucket':
+            print(f"Bucket {bucket_name} does not exist, skipping.")
+            continue
         else:
             raise error
-        
+            continue
+    except botocore.exceptions.ParamValidationError as error:
+        raise error
+        print(f'Validation errors with bucket: "{bucket_name}"')    
+        continue
     
     # BPA Settings 
     try:

--- a/yes3.py
+++ b/yes3.py
@@ -98,7 +98,7 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
 
     total_buckets = len(bucket_results)
 
-    print("Total Buckets: " + str(total_buckets))
+    print("Buckets Scanned: " + str(total_buckets))
     print("----------------------------")
 
     potentially_public = potential_public(bucket_results, account_results)
@@ -165,6 +165,7 @@ def add_to_bucket_summary(category, bucket_name):
 parser = argparse.ArgumentParser(prog='YES3 Scanner') 
 parser.add_argument("--profile")
 parser.add_argument("--region")
+parser.add_argument("--buckets", help="List of buckets to scan, comma separated and no spaces")
 
 args = parser.parse_args()
 session = boto3.Session(profile_name = args.profile)
@@ -221,11 +222,17 @@ access_issues = {}
 #Pagination is needed if quotas above 10,000
 
 try:
-    s3_buckets = s3_client.list_buckets()
+
+    if args.buckets:
+        bucket_listing = [{'Name': bucket} for bucket in args.buckets.split(',')]
+    else:
+        s3_buckets = s3_client.list_buckets()
+        bucket_listing = s3_buckets['Buckets']
+
 except botocore.exceptions.ClientError as error:
     raise error
 
-for bucket in s3_buckets['Buckets']:
+for bucket in bucket_listing:
 
     #TODO: Check Directory Buckets?
     bucket_name = bucket['Name']


### PR DESCRIPTION
This feature adds in the ability to take in buckets.

This is done by the `--buckets` argument which takes a comma-separated list of buckets (no spaces).