### PR TITLE
Add check for SSE-C encryption blocking on S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ python3 yes3.py --profile <your_profile_here>
 
 Note: While S3 is global, certain clients in AWS's boto3 require regions such as Service Quotas, S3 Control, and STS.  YES3 Scanner uses Service Quotas to check for bucket limits and the global limit only shows up in us-east-1.  Due to this, YES3 scanner will use `us-east-1 ` as the default region for Service Quotas, STS, and S3 Control. YES3 Scanner will account for buckets in all regions due to the global nature of S3.  Thus, YES3's API calls will be in CloudTrail in us-east-1.
 
+### Optional: Pass in buckets to scan
+
+By default, YES3 Scanner will scan all buckets in the region in the AWS Account.  To specify specific buckets to run YES3 Scanner on, the `--buckets` argument can be used.  The `--buckets` argument takes in a comma-separated list of bucket names (without spaces).
+
+Example command:
+
+```
+python3 yes3.py --profile <your_profile_here>  --buckets fog-bucket-1,fog-bucket-2,fog-bucket-3
+```
+
+
+### Example Output
+
 Example output:
 
 ```
@@ -73,7 +86,7 @@ Account Settings
 Account Block Public Access Overall Status: OK
 ----------------------------
 Bucket Summary
-Total Buckets: 14
+Buckets Scanned: 14
 ----------------------------
 Buckets potentially public: 3
 fog-pub-sample-bucket | Public Method: ['acl']

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Requirements can be installed via pip3 install and the requirements.txt file. A 
 pip3 install -r requirements.txt
 ```
 
+NOTE: YES3 requires an up-to-date version of boto3 due to recent changes in S3's apis. YES3 will warn you if your version of boto3 is out of date. See requirements for version requirements.
+
 For information on configuring your AWS Credentials, see AWS's documentation [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html)
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ YES3 scans an AWS Account for potential S3 security issues in the following cate
 
 * Access Issues such as Public Access
 * Preventative S3 Security Settings
-* Additional Security such as Encryption
+* Additional Security such as Encryption and SSE-C Encryption Blocking
 * Ransomware Protection, Data Protection, and Recovery
 
 For help or feedback, contact us at [info@fogsecurity.io](mailto:info@fogsecurity.io).  We are continuing to build in this space and are developing a more comprehensive scanner with multi-account (Organization) and object-level scanning.  If you're interested in joining a private beta, reach out to us.
@@ -34,6 +34,7 @@ YES3 Scanner checks for the following S3 configuration items:
 
 #### Additional Security
 - Bucket Encryption Settings
+- Whether a Bucket blocks SSE-C Encryption
 - S3 Server Access Logging
 
 #### Ransomware Protection & Recovery
@@ -97,6 +98,7 @@ Buckets with Access Issues: 1
 sample-locked-bucket
 ----------------------------
 Buckets with default S3-Owned Encryption: 6
+Buckets without SSE-C Encryption blocked: 1
 Buckets with a Block Public Access setting disabled: 3
 Buckets with Bucket ACLs Enabled: 2
 Buckets with ACLs set to public: 0
@@ -109,6 +111,8 @@ Buckets with Server Access Logs Disabled: 5
 ----------------------------
 Additional Bucket Details
 Buckets with default S3-Owned Encryption: sample-bucket-1, sample-bucket-2, sample-bucket-3, sample-bucket-4, sample-bucket-5, sample-bucket-6
+
+Buckets without SSE-C Encryption blocked: sample-bucket-2
 
 Buckets with a Block Public Access setting disabled: sample-bucket-1, sample-bucket-2, sample-bucket-3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto3>=1.34.57
-botocore>=1.34.57
+boto3>=1.41.0
+botocore>=1.41.0

--- a/yes3.py
+++ b/yes3.py
@@ -254,9 +254,16 @@ for bucket in bucket_listing:
     except botocore.exceptions.ClientError as error:
         if error.response['Error']['Code'] == 'AccessDenied':
             access_issue("BucketEncryption", bucket_name)
+        elif error.response['Error']['Code'] == 'NoSuchBucket':
+            print(f"Bucket {bucket_name} does not exist, skipping.")
+            continue
         else:
             raise error
-        
+            continue
+    except botocore.exceptions.ParamValidationError as error:
+        raise error
+        print(f'Validation errors with bucket: "{bucket_name}"')    
+        continue
     
     # BPA Settings 
     try:

--- a/yes3.py
+++ b/yes3.py
@@ -113,6 +113,7 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
     
     print("----------------------------")
     print("Buckets with default S3-Owned Encryption: " + str(len(bucket_results_summary['BucketEncryption'])))
+    print("Buckets without SSE-C Encryption blocked: " + str(len(bucket_results_summary['BucketNotSSECBlocked'])))
     print("Buckets with a Block Public Access setting disabled: " + str(len(bucket_results_summary['BucketBPA'])))
     print("Buckets with Bucket ACLs Enabled: " + str(len(bucket_results_summary['BucketACLEnabled'])))
     print("Buckets with ACLs set to public: " + str(len(bucket_results_summary['BucketACL'])))
@@ -127,6 +128,8 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
     print("Additional Bucket Details")
     print("Buckets with default S3-Owned Encryption: ", end="")
     print(*bucket_results_summary['BucketEncryption'], sep=', ')
+    print("Buckets without SSE-C Encryption blocked: ", end="")
+    print(*bucket_results_summary['BucketNotSSECBlocked'], sep=', ')
     print("\n" + "Buckets with a Block Public Access setting disabled: ", end="")
     print(*bucket_results_summary['BucketBPA'], sep=', ')
     print("\n" + "Buckets with Bucket ACLs Enabled: ", end="")
@@ -206,6 +209,7 @@ bucket_results = []
 
 bucket_results_summary = {
     'BucketEncryption': [],
+    'BucketNotSSECBlocked': [],
     'BucketBPA': [],
     'BucketACLEnabled': [],
     'BucketACL': [],

--- a/yes3.py
+++ b/yes3.py
@@ -98,7 +98,7 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
 
     total_buckets = len(bucket_results)
 
-    print("Total Buckets: " + str(total_buckets))
+    print("Buckets Scanned: " + str(total_buckets))
     print("----------------------------")
 
     potentially_public = potential_public(bucket_results, account_results)
@@ -165,6 +165,7 @@ def add_to_bucket_summary(category, bucket_name):
 parser = argparse.ArgumentParser(prog='YES3 Scanner') 
 parser.add_argument("--profile")
 parser.add_argument("--region")
+parser.add_argument("--buckets", help="List of buckets to scan, comma separated and no spaces")
 
 args = parser.parse_args()
 session = boto3.Session(profile_name = args.profile)
@@ -221,11 +222,17 @@ access_issues = {}
 #Pagination is needed if quotas above 10,000
 
 try:
-    s3_buckets = s3_client.list_buckets()
+
+    if args.buckets:
+        bucket_listing = [{'Name': bucket} for bucket in args.buckets.split(',')]
+    else:
+        s3_buckets = s3_client.list_buckets()
+        bucket_listing = s3_buckets['Buckets']
+
 except botocore.exceptions.ClientError as error:
     raise error
 
-for bucket in s3_buckets['Buckets']:
+for bucket in bucket_listing:
 
     #TODO: Check Directory Buckets?
     bucket_name = bucket['Name']

--- a/yes3.py
+++ b/yes3.py
@@ -59,6 +59,11 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
 
     #Account Results
     print("YES3 SCANNER RESULTS")
+
+    #Version check for SSE-C Encryption
+    if not (boto3.__version__ > '1.41.0'):
+        print("WARNING: boto3 version is outdated, please upgrade to version 1.41.0 or later for accurate results such as SSE-C encryption.")
+
     print("----------------------------")
     print("AWS Account: " + aws_account)
     print("Account Settings")

--- a/yes3.py
+++ b/yes3.py
@@ -133,7 +133,7 @@ def summarize_results(bucket_results, account_results, bucket_results_summary):
     print("Additional Bucket Details")
     print("Buckets with default S3-Owned Encryption: ", end="")
     print(*bucket_results_summary['BucketEncryption'], sep=', ')
-    print("Buckets without SSE-C Encryption blocked: ", end="")
+    print("\n" + "Buckets without SSE-C Encryption blocked: ", end="")
     print(*bucket_results_summary['BucketNotSSECBlocked'], sep=', ')
     print("\n" + "Buckets with a Block Public Access setting disabled: ", end="")
     print(*bucket_results_summary['BucketBPA'], sep=', ')

--- a/yes3.py
+++ b/yes3.py
@@ -260,6 +260,23 @@ for bucket in bucket_listing:
             #Bucket uses S3 Managed (AWS Owned)
             add_to_bucket_summary("BucketEncryption", bucket_name)
             encryption_key = 'None'
+
+        blocked_encryption_types = encryption['ServerSideEncryptionConfiguration']['Rules'][0].get('BlockedEncryptionTypes')
+
+        if blocked_encryption_types:
+            blocked_encryption = blocked_encryption_types['EncryptionType'][0]
+
+            if "SSE-C" in blocked_encryption:
+                #Bucket Blocks SSE-C Encryption
+                continue
+            elif "NONE" in blocked_encryption:
+                add_to_bucket_summary("BucketNotSSECBlocked", bucket_name)
+                #Bucket does not block SSE-C Encryption
+        else:
+            #Bucket does not block SSE-C Encryption        
+            #blocked_encryption = "NONE"
+            add_to_bucket_summary("BucketNotSSECBlocked", bucket_name)
+    
     except botocore.exceptions.ClientError as error:
         if error.response['Error']['Code'] == 'AccessDenied':
             access_issue("BucketEncryption", bucket_name)


### PR DESCRIPTION
This PR addresses a recent change by AWS for S3 bucket encryption configuration.

S3 buckets now have a feature to block SSE-C encryption.  

In early 2025, there were reports on SSE-C encryption being used for ransomware: https://www.fogsecurity.io/blog/ransomware-in-aws-s3-sse-c.

This addresses #24 and the change introduced here: https://aws.amazon.com/blogs/storage/advanced-notice-amazon-s3-to-disable-the-use-of-sse-c-encryption-by-default-for-all-new-buckets-and-select-existing-buckets-in-april-2026/